### PR TITLE
Fix buffer overflow in SRV record parsing

### DIFF
--- a/rtypes.c
+++ b/rtypes.c
@@ -146,7 +146,7 @@ char * srv(const uint8_t * packet, uint32_t pos, uint32_t id_pos,
     if (target == NULL) 
         return mk_error("Bad SRV", packet, pos, rdlength);
     
-    buffer = malloc(sizeof(char) * ((3*5+1) + strlen(target)));
+    buffer = malloc(sizeof(char) * ((3*5+3) + strlen(target)));
     sprintf(buffer, "%d,%d,%d %s", priority, weight, port, target);
     free(target);
     return buffer;


### PR DESCRIPTION
priority/weight/port are bound by 0-65535, so 5 chars for each, but we need to add 3 instead of just 1 to also handle the two commas and the space. I can include a test case that causes the error[1], but I would need to edit the pcap to ensure there isn't any PPI in it.

[1] error:
```
*** Error in `/home/yacin/src/dns_parse_orig/bin/dns_parse': free(): invalid pointer: 0x000000000121fe90 ***
```